### PR TITLE
editline: add live, token-based syntax highlighting

### DIFF
--- a/editline/editline.go
+++ b/editline/editline.go
@@ -19,6 +19,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/knz/bubbline/complete"
 	"github.com/knz/bubbline/editline/internal/textarea"
+	"github.com/knz/bubbline/highlight"
 	rw "github.com/mattn/go-runewidth"
 	"github.com/muesli/reflow/wordwrap"
 )
@@ -195,6 +196,9 @@ type Model struct {
 	// Only takes effect at Reset() or Focus().
 	ShowLineNumbers bool
 
+	// Highlighter is the syntax highlighting function to use.
+	Highlighter highlight.Highlighter
+
 	// externalEditorExt is the extension to use when creating a temporary file for
 	// an external editor.
 	externalEditorExt string
@@ -342,6 +346,7 @@ func (m *Model) Focus() tea.Cmd {
 	m.text.ShowLineNumbers = m.ShowLineNumbers
 	m.text.FocusedStyle = m.FocusedStyle.Editor
 	m.text.BlurredStyle = m.BlurredStyle.Editor
+	m.text.Highlighter = m.Highlighter
 	m.updatePrompt()
 	m.hctrl.pattern.PromptStyle = m.FocusedStyle.SearchInput.PromptStyle
 	m.hctrl.pattern.TextStyle = m.FocusedStyle.SearchInput.TextStyle

--- a/examples/live-highlight/main.go
+++ b/examples/live-highlight/main.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/knz/bubbline"
+	"github.com/knz/bubbline/highlight"
+)
+
+// simpleHighlighter is an example implementation of the highlight.Highlighter interface.
+// It provides live highlighting for a few keywords.
+type simpleHighlighter struct {
+	// Define complete styles for each token type.
+	styleKeyword lipgloss.Style
+	styleNumber  lipgloss.Style
+	styleDefault lipgloss.Style
+}
+
+// newSimpleHighlighter creates our highlighter with its styles pre-defined.
+func newSimpleHighlighter() *simpleHighlighter {
+	return &simpleHighlighter{
+		styleKeyword: lipgloss.NewStyle().Foreground(lipgloss.Color("33")).Bold(true), // Blue and Bold
+		styleNumber:  lipgloss.NewStyle().Foreground(lipgloss.Color("35")),            // Magenta
+		styleDefault: lipgloss.NewStyle(),                                             // Use the terminal's default foreground color
+	}
+}
+
+// Highlight tokenizes the line and applies styles.
+func (h *simpleHighlighter) Highlight(line string) []highlight.Token {
+	var tokens []highlight.Token
+
+	// This logic preserves spaces by finding words and the gaps between them.
+	var lastPos int
+	for _, word := range strings.Fields(line) {
+		idx := strings.Index(line[lastPos:], word)
+		// Add the whitespace before the word as a plain token.
+		if idx > 0 {
+			tokens = append(tokens, highlight.Token{
+				Value: line[lastPos : lastPos+idx],
+				Style: h.styleDefault,
+			})
+		}
+
+		// --- Start with the default style for every word ---
+		finalStyle := h.styleDefault
+
+		// --- Apply a specific style only if it matches a category ---
+		upperWord := strings.ToUpper(word)
+		if upperWord == "SELECT" || upperWord == "FROM" || upperWord == "WHERE" {
+			finalStyle = h.styleKeyword
+		} else if _, err := strconv.Atoi(word); err == nil {
+			finalStyle = h.styleNumber
+		}
+
+		// Add the word itself with its determined style.
+		tokens = append(tokens, highlight.Token{
+			Value: word,
+			Style: finalStyle,
+		})
+		lastPos += idx + len(word)
+	}
+	// Add any trailing whitespace.
+	if lastPos < len(line) {
+		tokens = append(tokens, highlight.Token{
+			Value: line[lastPos:],
+			Style: h.styleDefault,
+		})
+	}
+
+	return tokens
+}
+
+func main() {
+	fmt.Println("Live highlighter example. Type 'SELECT' or 'FROM' to see live highlighting. Ctrl+D to exit.")
+
+	m := bubbline.New()
+
+	// 1. Instantiate our highlighter using the constructor.
+	highlighter := newSimpleHighlighter()
+
+	// 2. Set it on the bubbline editor instance.
+	m.SetHighlighter(highlighter)
+
+	// 3. Run the editor.
+	for {
+		val, err := m.GetLine()
+
+		if err == io.EOF {
+			fmt.Println("\nBye!")
+			break
+		}
+		if err != nil {
+			fmt.Println("error:", err)
+			break
+		}
+		fmt.Printf("\nYou entered: %q\n", val)
+	}
+}

--- a/getline.go
+++ b/getline.go
@@ -9,6 +9,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/knz/bubbline/complete"
 	"github.com/knz/bubbline/editline"
+	"github.com/knz/bubbline/highlight"
 	"github.com/knz/bubbline/history"
 )
 
@@ -28,6 +29,11 @@ func New() *Editor {
 }
 
 var _ tea.Model = (*Editor)(nil)
+
+// SetHighlighter sets the syntax highlighting implementation for the editor.
+func (m *Editor) SetHighlighter(h highlight.Highlighter) {
+	m.Model.Highlighter = h
+}
 
 // Update is part of the tea.Model interface.
 func (m *Editor) Update(imsg tea.Msg) (tea.Model, tea.Cmd) {

--- a/highlight/highlight.go
+++ b/highlight/highlight.go
@@ -1,0 +1,16 @@
+package highlight
+
+import "github.com/charmbracelet/lipgloss"
+
+// Token represents a single styled segment of text.
+type Token struct {
+	Value string
+	Style lipgloss.Style
+}
+
+// Highlighter is the interface for a syntax highlighter that
+// can tokenize a line of text.
+type Highlighter interface {
+	// Highlight takes a line of text and returns a slice of styled Tokens.
+	Highlight(line string) []Token
+}


### PR DESCRIPTION
This introduces support for live, "as-you-type" syntax highlighting to improve readability for structured text formats like SQL.

The main change is a new token-based rendering path. A new public `highlight` package provides the core `Highlighter` interface, and the internal `textarea` component has been refactored to be token-aware.

The new feature is exposed via a `SetHighlighter()` method on the `bubbline.Editor` and `editline.Model`.