### PR TITLE
Thread Input/Output through to bubbletea program

### DIFF
--- a/complete/complete.go
+++ b/complete/complete.go
@@ -71,7 +71,7 @@ var DefaultStyles = func() (c Styles) {
 	c.FocusedTitleBar = lipgloss.NewStyle()
 	c.BlurredTitleBar = lipgloss.NewStyle()
 	c.FocusedTitle = lipgloss.NewStyle().Background(lipgloss.Color("62")).Foreground(lipgloss.Color("230"))
-	c.BlurredTitle = c.FocusedTitle.Copy().Foreground(subtle)
+	c.BlurredTitle = c.FocusedTitle.Foreground(subtle)
 	c.Spinner = ls.Spinner
 	c.FilterPrompt = ls.FilterPrompt
 	c.FilterCursor = ls.FilterCursor
@@ -212,7 +212,7 @@ func (r *renderer) Render(w io.Writer, m list.Model, index int, item list.Item) 
 	if r.m.selectedList == r.listIdx && index == m.Index() {
 		fn = st.SelectedItem.Render
 	}
-	fmt.Fprint(w, fn(s))
+	_, _ = fmt.Fprint(w, fn(s))
 }
 
 // Height is part of the list.ItemDelegate interface.

--- a/editline/editline.go
+++ b/editline/editline.go
@@ -310,7 +310,7 @@ func (m *Model) GetHistory() []string {
 // AddHistoryEntry adds an entry to the history navigation list.
 func (m *Model) AddHistoryEntry(s string) {
 	// Only add a new entry if it doesn't duplicate the last one.
-	if len(m.history) == 0 || !(m.DedupHistory && s == m.history[len(m.history)-1]) {
+	if len(m.history) == 0 || !m.DedupHistory || s != m.history[len(m.history)-1] {
 		m.history = append(m.history, s)
 	}
 	// Truncate if needed.
@@ -349,7 +349,7 @@ func (m *Model) Focus() tea.Cmd {
 	m.hctrl.pattern.PromptStyle = m.FocusedStyle.SearchInput.PromptStyle
 	m.hctrl.pattern.TextStyle = m.FocusedStyle.SearchInput.TextStyle
 	m.hctrl.pattern.PlaceholderStyle = m.FocusedStyle.SearchInput.PlaceholderStyle
-	m.hctrl.pattern.CursorStyle = m.FocusedStyle.SearchInput.CursorStyle
+	m.hctrl.pattern.Cursor.Style = m.FocusedStyle.SearchInput.CursorStyle
 	m.completions.Focus()
 
 	var cmd tea.Cmd
@@ -369,7 +369,7 @@ func (m *Model) Blur() {
 	m.hctrl.pattern.PromptStyle = m.BlurredStyle.SearchInput.PromptStyle
 	m.hctrl.pattern.TextStyle = m.BlurredStyle.SearchInput.TextStyle
 	m.hctrl.pattern.PlaceholderStyle = m.BlurredStyle.SearchInput.PlaceholderStyle
-	m.hctrl.pattern.CursorStyle = m.BlurredStyle.SearchInput.CursorStyle
+	m.hctrl.pattern.Cursor.Style = m.BlurredStyle.SearchInput.CursorStyle
 }
 
 // Init is part of the tea.Model interface.

--- a/editline/getline_test.go
+++ b/editline/getline_test.go
@@ -41,22 +41,22 @@ func TestBubbline(t *testing.T) {
 			catwalk.WithUpdater(testCmd),
 			catwalk.WithObserver("value", func(out io.Writer, m tea.Model) error {
 				s := m.(*bubbline.Editor).Value()
-				fmt.Fprintf(out, "%q", s)
+				_, _ = fmt.Fprintf(out, "%q", s)
 				return nil
 			}),
 			catwalk.WithObserver("history", func(out io.Writer, m tea.Model) error {
 				h := m.(*bubbline.Editor).GetHistory()
 				for _, e := range h {
-					fmt.Fprintf(out, "%s\n", e)
+					_, _ = fmt.Fprintf(out, "%s\n", e)
 				}
 				return nil
 			}),
 			catwalk.WithObserver("err", func(out io.Writer, m tea.Model) error {
 				e := m.(*bubbline.Editor).Err
 				if e != nil {
-					fmt.Fprintf(out, "%v", e)
+					_, _ = fmt.Fprintf(out, "%v", e)
 				} else {
-					fmt.Fprintf(out, "<no error>")
+					_, _ = fmt.Fprintf(out, "<no error>")
 				}
 				return nil
 			}),
@@ -91,9 +91,9 @@ func testCmd(m tea.Model, cmd string, args ...string) (bool, tea.Model, tea.Cmd,
 	case "limit_history_size":
 		t.MaxHistorySize = 2
 	case "unset_editor_env":
-		os.Unsetenv("EDITOR")
+		_ = os.Unsetenv("EDITOR")
 	case "set_editor_env":
-		os.Setenv("EDITOR", "invalid")
+		_ = os.Setenv("EDITOR", "invalid")
 	case "noop":
 	case "reset":
 		t.Reset()

--- a/editline/internal/textarea/textarea.go
+++ b/editline/internal/textarea/textarea.go
@@ -743,10 +743,7 @@ func (m *Model) wordRight() {
 
 func (m *Model) doWordRight(fn func(charIdx int, pos int)) {
 	// Skip spaces forward.
-	for {
-		if m.col < len(m.value[m.row]) && !unicode.IsSpace(m.value[m.row][m.col]) {
-			break
-		}
+	for m.col >= len(m.value[m.row]) || unicode.IsSpace(m.value[m.row][m.col]) {
 		if m.row == len(m.value)-1 && m.col == len(m.value[m.row]) {
 			// End of text.
 			break
@@ -842,9 +839,9 @@ func (m *Model) repositionView() {
 	max := min + m.viewport.Height - 1
 
 	if row := m.cursorLineNumber(); row < min {
-		m.viewport.LineUp(min - row)
+		m.viewport.ScrollUp(min - row)
 	} else if row > max {
-		m.viewport.LineDown(row - max)
+		m.viewport.ScrollDown(row - max)
 	}
 }
 

--- a/editline/internal/textarea/textarea_test.go
+++ b/editline/internal/textarea/textarea_test.go
@@ -29,35 +29,35 @@ func TestTextArea(t *testing.T) {
 			catwalk.WithUpdater(testCmd),
 			catwalk.WithObserver("value", func(out io.Writer, m tea.Model) error {
 				s := m.(*testModel).text.Value()
-				fmt.Fprintf(out, "%q", s)
+				_, _ = fmt.Fprintf(out, "%q", s)
 				return nil
 			}),
 			catwalk.WithObserver("runes", func(out io.Writer, m tea.Model) error {
 				s := m.(*testModel).text.ValueRunes()
-				fmt.Fprintf(out, "%+v", s)
+				_, _ = fmt.Fprintf(out, "%+v", s)
 				return nil
 			}),
 			catwalk.WithObserver("curline", func(out io.Writer, m tea.Model) error {
 				s := m.(*testModel).text.CurrentLine()
-				fmt.Fprintf(out, "%q", s)
+				_, _ = fmt.Fprintf(out, "%q", s)
 				return nil
 			}),
 			catwalk.WithObserver("props", func(out io.Writer, m tea.Model) error {
 				t := &m.(*testModel).text
-				fmt.Fprintf(out, "Focused: %v\n", t.Focused())
-				fmt.Fprintf(out, "Width: %d, Height: %d, LogicalHeight: %d\n", t.Width(), t.Height(), t.LogicalHeight())
-				fmt.Fprintf(out, "Length: %d, LineCount: %d, NumLinesInValue: %d, EmptyValue: %v\n",
+				_, _ = fmt.Fprintf(out, "Focused: %v\n", t.Focused())
+				_, _ = fmt.Fprintf(out, "Width: %d, Height: %d, LogicalHeight: %d\n", t.Width(), t.Height(), t.LogicalHeight())
+				_, _ = fmt.Fprintf(out, "Length: %d, LineCount: %d, NumLinesInValue: %d, EmptyValue: %v\n",
 					t.Length(), t.LineCount(), t.NumLinesInValue(), t.EmptyValue(),
 				)
 				return nil
 			}),
 			catwalk.WithObserver("pos", func(out io.Writer, m tea.Model) error {
 				t := &m.(*testModel).text
-				fmt.Fprintf(out, "Line: %d, Pos %d, (row %d, col %d, lastCharOffset %d)\n",
+				_, _ = fmt.Fprintf(out, "Line: %d, Pos %d, (row %d, col %d, lastCharOffset %d)\n",
 					t.Line(), t.CursorPos(), t.row, t.col, t.lastCharOffset,
 				)
-				fmt.Fprintf(out, "LineInfo: %+v\n", t.LineInfo())
-				fmt.Fprintf(out, "AtBeginningOfEmptyLine: %v, AtFirstLineOfInputAndView: %v, AtLastLineOfInputAndView: %v\n",
+				_, _ = fmt.Fprintf(out, "LineInfo: %+v\n", t.LineInfo())
+				_, _ = fmt.Fprintf(out, "AtBeginningOfEmptyLine: %v, AtFirstLineOfInputAndView: %v, AtLastLineOfInputAndView: %v\n",
 					t.AtBeginningOfEmptyLine(), t.AtFirstLineOfInputAndView(), t.AtLastLineOfInputAndView(),
 				)
 				return nil

--- a/examples/fancy/main.go
+++ b/examples/fancy/main.go
@@ -79,7 +79,7 @@ or the letter 'r'.`)
 		}
 
 		fmt.Printf("\nYou have entered: %q\n", val)
-		m.AddHistory(val)
+		_ = m.AddHistory(val)
 	}
 }
 

--- a/examples/getline-history/main.go
+++ b/examples/getline-history/main.go
@@ -39,6 +39,6 @@ func main() {
 		}
 
 		fmt.Printf("\nYou have entered: %q\n", val)
-		m.AddHistory(val)
+		_ = m.AddHistory(val)
 	}
 }

--- a/getline.go
+++ b/getline.go
@@ -3,6 +3,7 @@ package bubbline
 import (
 	"context"
 	"errors"
+	"io"
 	"os"
 	"os/signal"
 
@@ -18,6 +19,18 @@ type Editor struct {
 
 	autoSaveHistory bool
 	histFile        string
+
+	// Input, if non-nil, is the io.Reader the bubbletea program reads
+	// terminal events from. When nil (the default), bubbletea reads from
+	// the process's stdin. Embedders that drive the shell over a PTY or
+	// network stream set this to bind the editor to their I/O.
+	Input io.Reader
+
+	// Output, if non-nil, is the io.Writer the bubbletea program writes
+	// to. When nil (the default), bubbletea writes to the process's
+	// stdout. Set in tandem with Input when the editor is driven over a
+	// non-stdio transport.
+	Output io.Writer
 }
 
 // New instantiates an editor.
@@ -69,7 +82,14 @@ func (m *Editor) GetLine() (string, error) {
 		}
 	}()
 	// Create a Bubbletea program to handle our input.
-	p := tea.NewProgram(m, tea.WithoutSignalHandler(), tea.WithContext(ctx))
+	opts := []tea.ProgramOption{tea.WithoutSignalHandler(), tea.WithContext(ctx)}
+	if m.Input != nil {
+		opts = append(opts, tea.WithInput(m.Input))
+	}
+	if m.Output != nil {
+		opts = append(opts, tea.WithOutput(m.Output))
+	}
+	p := tea.NewProgram(m, opts...)
 	m.Reset()
 	if _, err := p.Run(); err != nil {
 		// Was a signal received?

--- a/getline.go
+++ b/getline.go
@@ -33,7 +33,7 @@ var _ tea.Model = (*Editor)(nil)
 func (m *Editor) Update(imsg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := imsg.(type) {
 	case tea.WindowSizeMsg:
-		m.Model.SetSize(msg.Width, msg.Height)
+		m.SetSize(msg.Width, msg.Height)
 
 	case editline.InputCompleteMsg:
 		return m, tea.Quit

--- a/history/history.go
+++ b/history/history.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"bytes"
 	"io"
-	"io/ioutil"
 	"os"
 )
 
@@ -40,7 +39,7 @@ func loadHistoryFromFile(f io.Reader) ([]string, error) {
 		return nil, nil
 	}
 	// Read the remainder of the file.
-	contents, err := ioutil.ReadAll(f)
+	contents, err := io.ReadAll(f)
 	if err != nil {
 		return nil, err
 	}

--- a/history/history_unix_test.go
+++ b/history/history_unix_test.go
@@ -5,7 +5,6 @@ package history
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 )
 
@@ -17,14 +16,14 @@ func Example_history() {
 	err = SaveHistory(nil, "/dev/null/notvalid")
 	fmt.Println(err)
 
-	f, err := ioutil.TempFile("", "test")
+	f, err := os.CreateTemp("", "test")
 	if err != nil {
 		fmt.Println(err)
 		return
 	}
 	fname := f.Name()
-	f.Close()
-	defer os.Remove(fname)
+	_ = f.Close()
+	defer func() { _ = os.Remove(fname) }()
 	err = SaveHistory(nil, fname)
 	fmt.Println(err)
 	_, err = LoadHistory(fname)


### PR DESCRIPTION
## Summary

Adds `Input` / `Output` fields on `bubbline.Editor` so embedders that drive the editor over a PTY pair, SSH channel, or any other non-stdio transport can bind the bubbletea program to those file descriptors. Without this, `GetLine()` unconditionally passes the program the process's stdin/stdout, which makes bubbline unusable as a library in a multi-tenant service.

This is the fork (`cockroachdb/bubbline`) of `knz/bubbline` — knz is no longer at CRL and we own this going forward. The change here is what `cockroachdb-sqlshell` (and downstream, ccloud-service's SSH gateway) needs to bind each session's editor to its own PTY.

## Commits

1. **Fix lint findings inherited from upstream** — pre-existing tech debt that the modernized golangci-lint started flagging. 20 issues across `editline/`, `complete/`, `history/`, `examples/`, `textarea/`, `getline.go`: deprecated APIs (`io/ioutil`, `viewport.LineUp/Down`, `textinput.CursorStyle`, `lipgloss.Copy()`), missing `errcheck`s in tests, a De Morgan simplification, redundant embedded-field selector. No behavior changes — separated into its own commit so the substantive change has a clean baseline.

2. **bubbline: thread Input/Output through to bubbletea program** — adds two exported `io.Reader` / `io.Writer` fields on `Editor`, set in the same direct-field-assignment style as `MaxHistorySize` / `Reflow` / etc. When non-nil they're passed through as `tea.WithInput` / `tea.WithOutput`. When nil the existing behavior is preserved byte-for-byte, so consumers that don't set them see no change.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` clean (0 issues)
- [x] Verified in `cockroachdb-sqlshell` that the new fields wire correctly through to the bubbline editor when set